### PR TITLE
Add .env.example for n8n-LineOA

### DIFF
--- a/n8n-LineOA/.env.example
+++ b/n8n-LineOA/.env.example
@@ -1,0 +1,29 @@
+# ============================================
+# n8n - lineOArag Workflow
+# Copy this file to .env and fill in values
+# ============================================
+
+# --- n8n Configuration ---
+N8N_PORT=5678
+N8N_ENCRYPTION_KEY=your-random-encryption-key
+
+# --- PostgreSQL ---
+POSTGRES_USER=n8n
+POSTGRES_PASSWORD=your-strong-password
+POSTGRES_DB=n8n
+
+# --- LINE Messaging API ---
+LINE_CHANNEL_ACCESS_TOKEN=your-line-channel-access-token
+LINE_CHANNEL_SECRET=your-line-channel-secret
+
+# --- Google Gemini API ---
+GEMINI_API_KEY=your-gemini-api-key
+GEMINI_HOST=https://generativelanguage.googleapis.com
+
+# --- Supabase - Vector Store (RAG documents) ---
+SUPABASE_VECTOR_HOST=https://your-project.supabase.co
+SUPABASE_VECTOR_SERVICE_ROLE=your-service-role-key
+
+# --- Supabase - Django Database (app data) ---
+SUPABASE_DJANGO_HOST=https://your-project.supabase.co
+SUPABASE_DJANGO_SERVICE_ROLE=your-service-role-key


### PR DESCRIPTION
Add a new .env.example template for the n8n-LineOA workflow. Provides placeholders and instructions to copy to .env and fill in values for n8n config (port, encryption key), PostgreSQL credentials, LINE Messaging API tokens, Google Gemini API settings, and Supabase (vector store and Django DB) service-role keys.